### PR TITLE
compatibility to the jsmath plugin

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -8,8 +8,8 @@
 $conf['url'] = 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML';
 $conf['config'] = 'MathJax.Hub.Config({
     tex2jax: {
-        inlineMath: [ ["$","$"], ["\\\\(","\\\\)"] ],
-        displayMath: [ ["$$","$$"], ["\\\\[","\\\\]"] ],
+        inlineMath: [ ["$","$"], ["\\\\(","\\\\)"],["<jsm>","</jsm>"] ],
+        displayMath: [ ["$$","$$"], ["\\\\[","\\\\]"],["<jsmath>","</jsmath>"] ],
         processEscapes: true
     }
 });';

--- a/syntax/protecttex.php
+++ b/syntax/protecttex.php
@@ -60,6 +60,8 @@ class syntax_plugin_mathjax_protecttex extends DokuWiki_Syntax_Plugin {
         foreach (self::$ENVIRONMENTS as $env) {
             $this->Lexer->addEntryPattern('\\\\begin{' . $env . '}(?=.*?\\\\end{' . $env . '})',$mode,'plugin_mathjax_protecttex');
         }
+        $this->Lexer->addEntryPattern('<jsm>(?=.*?</jsm>)',$mode,'plugin_mathjax_protecttex');
+        $this->Lexer->addEntryPattern('<jsmath>(?=.*?</jsmath>)',$mode,'plugin_mathjax_protecttex');
     }
     public function postConnect() {
         $this->Lexer->addExitPattern('\$(?=[^\$])','plugin_mathjax_protecttex');
@@ -68,6 +70,8 @@ class syntax_plugin_mathjax_protecttex extends DokuWiki_Syntax_Plugin {
         foreach (self::$ENVIRONMENTS as $env) {
             $this->Lexer->addExitPattern('\\\\end{' . $env . '}','plugin_mathjax_protecttex');
         }
+        $this->Lexer->addExitPattern('</jsm>','plugin_mathjax_protecttex');
+        $this->Lexer->addExitPattern('</jsmath>','plugin_mathjax_protecttex');
     }
 
     public function handle($match, $state, $pos, &$handler){


### PR DESCRIPTION
I was using the mathjax service through jsmath plugin in dowkuwiki. And most of my formulas were produced with the tag <jsm></jsm> and <jsmath></jsmath>.

This commit adds compatibility to these tags both in the syntax and mathjax configuration. 
