### PR TITLE
Added support for plugin:latexport

### DIFF
--- a/syntax/protecttex.php
+++ b/syntax/protecttex.php
@@ -147,16 +147,18 @@ class syntax_plugin_mathjax_protecttex extends DokuWiki_Syntax_Plugin {
             return true;
         }
 
-        if ($mode == 'latex') {
+        if ($mode == 'latex') {
 
             $renderer->doc .= $data;
             return true;
         }
-		
-		if ($mode == 'latexport') {
-		    $renderer->mathjax_content($data);
-		}
-		
+
+        if ($mode == 'latexport') {
+
+            $renderer->mathjax_content($data);	
+            return true;
+        }
+
         return false;
     }
 }

--- a/syntax/protecttex.php
+++ b/syntax/protecttex.php
@@ -152,6 +152,11 @@ class syntax_plugin_mathjax_protecttex extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= $data;
             return true;
         }
+		
+		if ($mode == 'latexport') {
+		    $renderer->mathjax_content($data);
+		}
+		
         return false;
     }
 }


### PR DESCRIPTION
# Why?
- Because I've published a new plugin https://www.dokuwiki.org/plugin:latexport
- Plugin exports Dokuwiki documents into Latex documents, that can be transformed into PDF.
- Mathjax plugin displays mathematical equations written in Latex format.

This makes Mathjax a beautiful plugin to use together with mine. 

# Modification
I've added a specific call that occurs only in mode ``latexport``, and placed it besides other similar calls.

# Check it in action
Use the following links:
- http://microcontroleur.agl-developpement.ch/test
- http://microcontroleur.agl-developpement.ch/test?do=export_latexport_tex